### PR TITLE
[fix] Admin이 Member 정보(이름+상태) 변경 실패 수정

### DIFF
--- a/src/main/kotlin/com/back/domain/admin/service/AdminService.java
+++ b/src/main/kotlin/com/back/domain/admin/service/AdminService.java
@@ -54,7 +54,13 @@ public class AdminService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException(ResultCode.MEMBER_NOT_FOUND.code(), "해당 회원이 존재하지 않습니다."));
 
-        // 프로필 이미지 변경
+        // 이름 변경 - @NotBlank로 보장됨
+        member.updateName(request.getName());
+
+        // 상태 변경 - @NotNull로 보장됨  
+        member.changeStatus(request.getStatus());
+
+        // 프로필 이미지 변경 - nullable 필드
         if (request.getProfileUrl() != null) {
             String profileUrl = request.getProfileUrl().trim().isEmpty() ? null : request.getProfileUrl();
             member.updateProfileUrl(profileUrl);

--- a/src/main/kotlin/com/back/domain/admin/service/AdminService.java
+++ b/src/main/kotlin/com/back/domain/admin/service/AdminService.java
@@ -62,8 +62,8 @@ public class AdminService {
 
         // 프로필 이미지 변경 - nullable 필드
         if (request.getProfileUrl() != null) {
-            String profileUrl = request.getProfileUrl().trim().isEmpty() ? null : request.getProfileUrl();
-            member.updateProfileUrl(profileUrl);
+            final String trimmedUrl = request.getProfileUrl().trim();
+            member.updateProfileUrl(trimmedUrl.isEmpty() ? null : trimmedUrl);
         }
 
         memberRepository.save(member);

--- a/src/main/kotlin/com/back/domain/member/entity/Member.java
+++ b/src/main/kotlin/com/back/domain/member/entity/Member.java
@@ -127,6 +127,11 @@ public class Member extends BaseEntity {
     }
 
     public void changeStatus(Status newStatus) {
+        // 탈퇴한 회원은 다른 상태로 변경 불가
+        if (this.status == Status.DELETED) {
+            throw new IllegalStateException("탈퇴한 회원의 상태는 변경할 수 없습니다.");
+        }
+
         this.status = newStatus;
     }
     // 회원 정보 수정 - 끝

--- a/src/test/kotlin/com/back/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/kotlin/com/back/domain/admin/controller/AdminControllerTest.java
@@ -158,7 +158,7 @@ public class AdminControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"))
-                .andExpect(jsonPath("$.msg").value("해당 회원이 존재하지 않습니다."));
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 회원입니다."));
     }
 
     // ========== 특허 관련 테스트 시나리오 ==========


### PR DESCRIPTION
## 📢 기능 설명

관리자 계정으로 Member 정보 변경 시, 이름+상태가 변경되지 않는 오류 발생
====
updateMemberInfo 메서드에서 실수로 누락했음

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #84 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 관리자 화면에서 회원 정보 수정 시 이름과 상태를 함께 업데이트 가능.
  - 프로필 이미지 URL은 값이 있을 때만 반영하고 빈 문자열은 제거.

- 개선
  - 조회 실패 시 일관된 오류 처리로 안정성 향상.
  - DTO 값이 그대로 적용되도록 업데이트 로직 단순화되어 트랜잭션 내 반영신뢰성 증가.

- 버그 수정
  - 탈퇴한 회원의 상태 변경 시도는 차단되어 잘못된 상태 변경 방지.

- 테스트
  - 관리자 관련 테스트의 예외 메시지 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->